### PR TITLE
feat(semantic): implement strict error handling type checking

### DIFF
--- a/LANGUAGE_SPEC.md
+++ b/LANGUAGE_SPEC.md
@@ -1045,48 +1045,127 @@ import { List, Map } from "collections"
 
 ## 11. Error Handling
 
-### 11.1 Try-Catch-Finally
+### 11.1 Error Objects
+
+Tarqeem uses a structured error handling model. **Only error objects can be thrown** - strings, numbers, and other primitive types cannot be thrown directly.
+
+> **Note:** The word `خطأ` is reserved for the boolean value `false`. The base exception class is named `استثناء` (exception).
+
+#### Base Exception Class
+
+The base exception class `استثناء` provides the foundation for all throwable types:
+
+```tarqeem
+صنف استثناء {
+    عام رسالة: نص              // Error message
+    عام رسالة_عربية: نص        // Arabic error message (optional)
+
+    منشئ(رسالة: نص) {
+        هذا.رسالة = رسالة
+        هذا.رسالة_عربية = رسالة
+    }
+
+    منشئ(رسالة: نص، رسالة_عربية: نص) {
+        هذا.رسالة = رسالة
+        هذا.رسالة_عربية = رسالة_عربية
+    }
+}
+```
+
+#### Standard Exception Types
+
+The standard library provides specialized exception classes:
+
+| Arabic | English | Description |
+|--------|---------|-------------|
+| `استثناء_قيمة` | `ValueError` | Invalid value |
+| `استثناء_نوع` | `TypeError` | Type mismatch |
+| `استثناء_فهرس` | `IndexError` | Index out of bounds |
+| `استثناء_ملف` | `FileError` | File operation error |
+| `استثناء_شبكة` | `NetworkError` | Network error |
+| `استثناء_قسمة` | `DivisionError` | Division by zero |
+
+#### Custom Exception Classes
+
+Create custom exception types by extending `استثناء`:
+
+```tarqeem
+صنف استثناء_تحقق يرث استثناء {
+    عام الحقل: نص
+
+    منشئ(الحقل: نص، رسالة: نص) {
+        أساس(رسالة)
+        هذا.الحقل = الحقل
+    }
+}
+```
+
+### 11.2 Try-Catch-Finally
 
 ```tarqeem
 حاول {
     // Code that might throw
     متغير نتيجة = عملية_خطرة()
-} التقط (خطأ) {
-    // Handle error
-    اطبع("حدث خطأ: " + خطأ.رسالة)
+} التقط (خ) {
+    // Handle exception - 'خ' is typed as the base exception class
+    اطبع("حدث استثناء: " + خ.رسالة)
 } أخيراً {
-    // Always executed
+    // Always executed (cleanup)
     تنظيف()
 }
 ```
 
-### 11.2 Throw Statement
+**Note:** The catch parameter is automatically typed as `استثناء`, which provides access to the `.رسالة` property and other exception fields.
+
+### 11.3 Throw Statement
+
+The `ارمِ` (throw) statement **requires an exception object**:
 
 ```tarqeem
 دالة قسمة(أ: عدد، ب: عدد) -> عدد {
     إذا (ب == 0) {
-        ارمِ "لا يمكن القسمة على صفر"
+        // Correct: throw an exception object
+        ارمِ جديد استثناء_قسمة("لا يمكن القسمة على صفر")
     }
     أرجع أ / ب
 }
+
+// Using a helper function
+دالة استثناء_جديد(رسالة: نص) -> استثناء {
+    أرجع جديد استثناء(رسالة)
+}
+
+دالة ف() {
+    ارمِ استثناء_جديد("حدث استثناء")
+}
 ```
 
-### 11.3 Error Propagation
+**Invalid throws (compile-time errors):**
+```tarqeem
+// These will cause compile-time errors:
+ارمِ "نص"           // ❌ Cannot throw string
+ارمِ 42              // ❌ Cannot throw number
+ارمِ صحيح           // ❌ Cannot throw boolean
+ارمِ جديد شخص()    // ❌ Cannot throw non-exception class
+```
 
-Errors propagate up the call stack until caught:
+### 11.4 Error Propagation
+
+Exceptions propagate up the call stack until caught:
+
 ```tarqeem
 دالة أ() {
-    ب()  // Error from ب() propagates if not caught
+    ب()  // Exception from ب() propagates if not caught
 }
 
 دالة ب() {
-    ارمِ "خطأ"
+    ارمِ جديد استثناء("استثناء من ب")
 }
 
 حاول {
     أ()
 } التقط (خ) {
-    اطبع(خ)  // Catches error from ب()
+    اطبع(خ.رسالة)  // Catches exception from ب()
 }
 ```
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -262,7 +262,7 @@ impl Analyzer {
             }
 
             StmtKind::Throw(expr) => {
-                self.analyze_expr(expr);
+                self.analyze_throw(expr, stmt.span);
             }
 
             StmtKind::Import { items, from } => {
@@ -694,8 +694,13 @@ impl Analyzer {
 
         if let Some(catch_clause) = catch {
             self.push_scope(ScopeKind::Block);
-            self.scope
-                .define(Symbol::variable(&catch_clause.param, Type::Any, false));
+            // The catch parameter is typed as the base error class (استثناء)
+            // This ensures .رسالة (message) property access works correctly
+            self.scope.define(Symbol::variable(
+                &catch_clause.param,
+                Type::Class("استثناء".to_string()),
+                false,
+            ));
 
             for stmt in &catch_clause.body.statements {
                 self.analyze_stmt(stmt);
@@ -706,6 +711,26 @@ impl Analyzer {
 
         if let Some(finally_block) = finally {
             self.analyze_block(finally_block, ScopeKind::Block);
+        }
+    }
+
+    /// Analyze a throw statement - requires an error object
+    fn analyze_throw(&mut self, expr: &Expr, span: Span) {
+        let expr_type = self.analyze_expr(expr);
+
+        // Check that the thrown expression is an error type
+        if !self.is_error_type(&expr_type) {
+            self.error(
+                &format!(
+                    "Cannot throw non-error type '{}'. Only error objects (خطأ or subclasses) can be thrown",
+                    expr_type
+                ),
+                &format!(
+                    "لا يمكن رمي نوع غير خطأ '{}'. يمكن رمي كائنات الخطأ (خطأ أو أصنافه الفرعية) فقط",
+                    expr_type.arabic_name()
+                ),
+                span,
+            );
         }
     }
 
@@ -832,6 +857,33 @@ impl Analyzer {
     fn warn(&mut self, message: &str, message_ar: &str, span: Span) {
         self.diagnostics
             .push(Diagnostic::warning(message, message_ar, span));
+    }
+
+    // ============ Error Type Checking ============
+
+    /// Base error class names (Arabic and English)
+    /// Note: "خطأ" is reserved for the `false` boolean, so we use "استثناء" (exception)
+    const ERROR_BASE_CLASSES: &'static [&'static str] = &["استثناء", "Exception", "Error"];
+
+    /// Check if a type is an error type (is استثناء or inherits from it)
+    fn is_error_type(&self, ty: &Type) -> bool {
+        match ty {
+            Type::Class(class_name) => {
+                // Check if it's a base error class
+                if Self::ERROR_BASE_CLASSES.contains(&class_name.as_str()) {
+                    return true;
+                }
+                // Check if it inherits from a base error class
+                for base_error in Self::ERROR_BASE_CLASSES {
+                    if self.class_resolver.is_subclass(class_name, base_error) {
+                        return true;
+                    }
+                }
+                false
+            }
+            Type::Any => true, // Allow Any for backwards compatibility
+            _ => false,
+        }
     }
 
     /// Analyze a super constructor call: أساس(args)
@@ -1858,6 +1910,141 @@ mod tests {
             r#"
             متغير كلمة = "مرحبا";
             متغير ط = كلمة.طول;
+        "#,
+        );
+        assert!(result.is_ok());
+    }
+
+    // ============ Error Handling Tests ============
+
+    #[test]
+    fn test_throw_error_object() {
+        // Throwing an error object should succeed
+        // Note: "خطأ" is reserved for `false`, so we use "استثناء" (exception)
+        let result = analyze(
+            r#"
+            صنف استثناء {
+                عام رسالة: نص;
+                منشئ(رسالة: نص) {
+                    هذا.رسالة = رسالة;
+                }
+            }
+            دالة ف() {
+                ارمِ جديد استثناء("حدث خطأ");
+            }
+        "#,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_throw_error_subclass() {
+        // Throwing a subclass of استثناء should succeed
+        let result = analyze(
+            r#"
+            صنف استثناء {
+                عام رسالة: نص;
+            }
+            صنف استثناء_قيمة يرث استثناء {
+                عام القيمة: عدد;
+            }
+            دالة ف() {
+                ارمِ جديد استثناء_قيمة();
+            }
+        "#,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_throw_string_fails() {
+        // Throwing a string should fail
+        let result = analyze(
+            r#"
+            دالة ف() {
+                ارمِ "رسالة";
+            }
+        "#,
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("non-error type")));
+    }
+
+    #[test]
+    fn test_throw_number_fails() {
+        // Throwing a number should fail
+        let result = analyze(
+            r#"
+            دالة ف() {
+                ارمِ 42;
+            }
+        "#,
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("non-error type")));
+    }
+
+    #[test]
+    fn test_throw_non_error_class_fails() {
+        // Throwing a non-error class should fail
+        let result = analyze(
+            r#"
+            صنف شخص {
+                عام الاسم: نص;
+            }
+            دالة ف() {
+                ارمِ جديد شخص();
+            }
+        "#,
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("non-error type")));
+    }
+
+    #[test]
+    fn test_catch_parameter_typed_as_error() {
+        // Catch parameter should be typed as استثناء
+        // This test validates that we can access .رسالة on the catch parameter
+        let result = analyze(
+            r#"
+            صنف استثناء {
+                عام رسالة: نص;
+            }
+            دالة ف() {
+                حاول {
+                    متغير س = 1;
+                } التقط (خ) {
+                    متغير م = خ.رسالة;
+                }
+            }
+        "#,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_try_catch_finally() {
+        // Complete try-catch-finally block should work
+        let result = analyze(
+            r#"
+            صنف استثناء {
+                عام رسالة: نص;
+                منشئ(رسالة: نص) {
+                    هذا.رسالة = رسالة;
+                }
+            }
+            دالة ف() {
+                حاول {
+                    ارمِ جديد استثناء("حدث استثناء");
+                } التقط (خ) {
+                    متغير م = خ.رسالة;
+                } أخيراً {
+                    متغير ن = 1;
+                }
+            }
         "#,
         );
         assert!(result.is_ok());


### PR DESCRIPTION
- Add is_error_type() helper to check if a type is an exception class
- Update analyze_throw() to require exception objects (استثناء or subclasses)
- Type catch parameter as استثناء to ensure .رسالة property access works
- Add comprehensive tests for error handling type checking
- Update LANGUAGE_SPEC.md to document exception handling semantics

Breaking change: Throwing non-exception types (strings, numbers, etc.)
now produces a compile-time error. Only استثناء, Exception, Error or
their subclasses can be thrown.

Note: "خطأ" is reserved for the boolean value `false`, so the base
exception class is named "استثناء" (exception).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error handling model to use structured error objects instead of textual exceptions with bilingual message support.

* **New Features**
  * Introduced standardized exception types with a base exception class.
  * Added compile-time validation to ensure only exception objects can be thrown.

* **Tests**
  * Added comprehensive test suite for error handling and exception propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->