### PR TITLE
Fix slow parser match statement tests

### DIFF
--- a/src/parser/parser_tests.rs
+++ b/src/parser/parser_tests.rs
@@ -227,10 +227,10 @@ fn test_parse_match_statement() {
 #[test]
 fn test_parse_match_with_multiple_patterns() {
     let source = r#"
-        match (day) {
-            case 1, 2, 3 => print("weekday")
-            case 6, 7 => print("weekend")
-            default => print("unknown")
+        تطابق (يوم) {
+            حالة 1، 2، 3 => اطبع("يوم عمل")
+            حالة 6، 7 => اطبع("عطلة")
+            غير_ذلك => اطبع("غير معروف")
         }
     "#;
     let mut parser = parser_with_markers(source);
@@ -251,13 +251,13 @@ fn test_parse_match_with_multiple_patterns() {
 #[test]
 fn test_parse_match_with_block_body() {
     let source = r#"
-        match (x) {
-            case 1 => {
-                y = 10;
-                z = 20;
+        تطابق (س) {
+            حالة 1 => {
+                ص = 10؛
+                ع = 20؛
             }
-            default => {
-                y = 0;
+            غير_ذلك => {
+                ص = 0؛
             }
         }
     "#;

--- a/src/parser/precedence.rs
+++ b/src/parser/precedence.rs
@@ -29,8 +29,9 @@ impl Precedence {
             | TokenKind::MinusEqual
             | TokenKind::StarEqual
             | TokenKind::SlashEqual
-            | TokenKind::PercentEqual
-            | TokenKind::FatArrow => Precedence::Assignment,
+            | TokenKind::PercentEqual => Precedence::Assignment,
+            // Note: FatArrow (=>) is NOT an infix operator - it's handled by
+            // parse_match_statement and try_parse_arrow_function directly
 
             TokenKind::Question => Precedence::Ternary,
 
@@ -92,7 +93,6 @@ impl Precedence {
                 | TokenKind::SlashEqual
                 | TokenKind::PercentEqual
                 | TokenKind::StarStar
-                | TokenKind::FatArrow
         )
     }
 }


### PR DESCRIPTION
Root cause: FatArrow (=>) had Precedence::Assignment in the precedence table, but was not handled in parse_infix(). This caused parse_precedence() to loop infinitely when encountering => in match arms:
1. After parsing pattern (e.g., `1`), current token is `=>`
2. FatArrow has Precedence::Assignment (same as parse_expression uses)
3. Loop condition `precedence > op_prec` was false (1 > 1 = false)
4. parse_infix() returned without advancing (FatArrow not handled)
5. Infinite loop

Fix: Remove FatArrow from precedence table. The => token is only used in specific contexts (match arms and arrow functions) that are handled by their own parsing functions, not as a general infix operator.

Also fix two match tests that used English keywords (match, case, default) which are no longer supported since Arabic-only enforcement was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Localized match construct tests to Arabic for expanded language support.

* **Bug Fixes**
  * Corrected fat arrow operator handling in expression parsing to ensure proper operator precedence and associativity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->