### PR TITLE
fix(pkg): run install after removing a dependency

### DIFF
--- a/src/cli/pm/remove.rs
+++ b/src/cli/pm/remove.rs
@@ -34,7 +34,9 @@ pub fn run(package: String) -> PackageResult<()> {
         .green()
     );
 
-    // TODO: Run install to update packages directory
+    // Run install to update packages directory and lockfile
+    println!("{}", "→ Updating packages... / جاري تحديث الحزم...".cyan());
+    super::install::run(false)?;
 
     Ok(())
 }


### PR DESCRIPTION
After removing a package from the manifest, the remove command now runs
the install command to update the packages directory and lockfile,
ensuring they stay in sync with the manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency removal now properly updates packages and lockfile after uninstalling. Previously, the removal process was incomplete, leaving package references out of sync. This fix ensures consistent package management across your project environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->