### PR TITLE
Reduce unnecessary comments in codebase

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,165 @@
+---
+paths: src/**/*.rs
+---
+
+# Code Comments Philosophy
+
+This file defines when and how to use comments in the Tarqeem codebase.
+
+## The Core Principle
+
+**Comments should explain WHY, not WHAT.**
+
+Just as the Arabic philosophy states "الوصف لا الترجمة" (description, not translation) - comments should not translate code into English. The code itself is the "what"; comments add context the code cannot express.
+
+## When NOT to Comment
+
+### 1. Self-Evident Code
+
+```rust
+// BAD: Restates what the code does
+// Check for newlines
+if c == '\n' {
+    return self.make_token(TokenKind::Newline);
+}
+
+// GOOD: No comment needed - the code is clear
+if c == '\n' {
+    return self.make_token(TokenKind::Newline);
+}
+```
+
+### 2. Self-Documenting Names
+
+```rust
+// BAD: Function name already says this
+/// Checks if the character is a digit
+fn is_digit(&self, c: char) -> bool { }
+
+// GOOD: No doc needed - name is descriptive
+fn is_digit(&self, c: char) -> bool { }
+```
+
+### 3. Obvious Enum Variants
+
+```rust
+// BAD: Just restates the type name
+pub enum IrType {
+    /// Boolean (1-bit integer)
+    Bool,
+    /// 64-bit signed integer
+    Int,
+    /// 64-bit floating point
+    Float,
+}
+
+// GOOD: Only document if non-obvious
+pub enum IrType {
+    Bool,
+    Int,
+    Float,
+    /// Pointer to heap-allocated UTF-8 string with length prefix
+    String,
+}
+```
+
+### 4. ASCII Art Section Headers
+
+```rust
+// BAD: Visual clutter
+// ============ Helper Methods ============
+
+// GOOD: Use well-named impls or modules for organization
+impl Lexer {
+    // Helper methods naturally grouped here
+}
+```
+
+## When TO Comment
+
+### 1. Design Decisions
+
+```rust
+// GOOD: Explains WHY this choice was made
+// English letters are explicitly rejected to enforce Arabic-only identifiers
+fn is_identifier_start(&self, c: char) -> bool {
+    c == '_' || self.is_arabic_letter(c)
+}
+```
+
+### 2. Non-Obvious Domain Knowledge
+
+```rust
+// GOOD: Explains domain-specific behavior
+// NFC normalization ensures Arabic identifiers with different Unicode
+// representations (composed vs decomposed) are treated as identical
+fn normalize_name(name: &str) -> String {
+    name.nfc().collect()
+}
+```
+
+### 3. Complex Algorithms
+
+```rust
+// GOOD: Explains the approach
+// Method resolution follows C3 linearization:
+// 1. Check the class itself
+// 2. Check implemented interfaces
+// 3. Check parent class recursively
+fn resolve_method(&self, class: &ClassType, name: &str) -> Option<&Method> {
+```
+
+### 4. Workarounds and Edge Cases
+
+```rust
+// GOOD: Explains why this unusual code exists
+// LLVM requires opaque pointers in version 15+; we can't use typed pointers
+let ptr_type = context.ptr_type(AddressSpace::default());
+```
+
+### 5. Public API Documentation
+
+```rust
+/// Parses a variable declaration.
+///
+/// # Grammar
+/// ```text
+/// متغير <name> [: <type>] = <expr>
+/// ```
+pub fn parse_var_decl(&mut self) -> ParseResult<Stmt> { }
+```
+
+## Comment Cleanup Checklist
+
+Before committing, ask for each comment:
+
+1. **Does the code already say this?** → Delete the comment
+2. **Would renaming make this clear?** → Rename instead of comment
+3. **Is this explaining "what" or "why"?** → Keep only "why"
+4. **Is this a section header?** → Use code structure instead
+5. **Would a new developer need this?** → Keep if truly non-obvious
+
+## Bilingual Comments Exception
+
+For Arabic keyword mappings, include both languages:
+
+```rust
+// GOOD: Helps developers unfamiliar with Arabic
+TokenKind::Let        // متغير
+TokenKind::Const      // ثابت
+TokenKind::Function   // دالة
+```
+
+## Summary
+
+| Comment Type | Action |
+|--------------|--------|
+| Restates code | Delete |
+| Section headers (ASCII art) | Delete, use code structure |
+| Obvious type/field docs | Delete |
+| Design decisions | Keep |
+| Domain knowledge | Keep |
+| Complex algorithms | Keep |
+| Workarounds/edge cases | Keep |
+| Public API grammar | Keep |
+| Arabic keyword mappings | Keep |

--- a/.claude/rules/rust-style.md
+++ b/.claude/rules/rust-style.md
@@ -85,36 +85,18 @@ pub enum ParseError {
 
 ## Documentation
 
-### Document public APIs
+See `.claude/rules/comments.md` for the full commenting philosophy.
+
+**Key principle**: Comments explain WHY, not WHAT. Don't translate code into English.
 
 ```rust
-/// Parses a variable declaration statement.
-///
-/// # Grammar
-/// ```text
-/// متغير <name> [: <type>] = <expr>
-/// ثابت <name> [: <type>] = <expr>
-/// ```
-///
-/// # Examples
-/// ```
-/// let stmt = parser.parse_var_decl()?;
-/// ```
-pub fn parse_var_decl(&mut self) -> ParseResult<Stmt> { }
-```
+// BAD: Restates code
+// Check for newlines
+if c == '\n' { }
 
-### Document complex logic
-
-```rust
-fn resolve_method(&self, class: &ClassType, name: &str) -> Option<&Method> {
-    // Method resolution order (MRO):
-    // 1. Check the class itself
-    // 2. Check implemented interfaces
-    // 3. Check parent class (recursively)
-    // This follows a linearized C3 superclass ordering.
-
-    // ...implementation
-}
+// GOOD: Explains design decision
+// English letters explicitly rejected to enforce Arabic-only identifiers
+fn is_identifier_start(&self, c: char) -> bool { }
 ```
 
 ## Struct Organization

--- a/src/ir/builder.rs
+++ b/src/ir/builder.rs
@@ -41,62 +41,25 @@ impl std::error::Error for IrError {}
 
 type Result<T> = std::result::Result<T, IrError>;
 
-/// IR Builder for converting AST to IR
+/// Converts AST to IR
 pub struct IrBuilder {
-    /// The module being built
     module: Module,
-
-    /// Current function being built
     current_function: Option<Function>,
-
-    /// Current block ID
     current_block: BlockId,
-
-    /// Variable counter for SSA naming
     var_counter: u32,
-
-    /// Block counter
     block_counter: u32,
-
-    /// Variable name to VarId mapping (for current scope)
     variables: HashMap<String, VarId>,
-
-    /// Variable type tracking - maps VarId to its IrType
     var_types: HashMap<u32, IrType>,
-
-    /// Stack of variable scopes
     scope_stack: Vec<HashMap<String, VarId>>,
-
-    /// Loop context stack (continue_block, break_block)
-    loop_stack: Vec<(BlockId, BlockId)>,
-
-    /// Class field information
+    loop_stack: Vec<(BlockId, BlockId)>, // (continue_block, break_block)
     class_fields: HashMap<String, Vec<(String, IrType)>>,
-
-    /// Method return types: (ClassName::MethodName) -> IrType
     method_return_types: HashMap<String, IrType>,
-
-    /// Known function names for identifier resolution
     function_names: HashSet<String>,
-
-    /// Function return types: name -> IrType
-    /// Used to properly type recursive calls and cross-function calls
     function_return_types: HashMap<String, IrType>,
-
-    /// Track which VarIds are function parameters (not allocas)
-    /// Parameters are passed by value and don't need Load instructions
+    // Parameters are passed by value and don't need Load instructions
     parameters: HashSet<u32>,
-
-    /// Global constants: name -> (value, type)
-    /// These are constants declared at module level that are visible in all functions
     global_constants: HashMap<String, (Constant, IrType)>,
-
-    /// Global variable names (both mutable and immutable)
-    /// Used to distinguish global vs local variables during code generation
     global_variables: HashSet<String>,
-
-    /// Global variable types: name -> IrType
-    /// Used for type information when loading/storing globals
     global_var_types: HashMap<String, IrType>,
 }
 
@@ -557,9 +520,6 @@ impl IrBuilder {
         }
     }
 
-    // ==================== Statement Building ====================
-
-    /// Build IR for a statement
     fn build_stmt(&mut self, stmt: &Stmt) -> Result<()> {
         match &stmt.kind {
             StmtKind::VarDecl { name, ty, init, .. } => {
@@ -1846,9 +1806,6 @@ impl IrBuilder {
         Ok(())
     }
 
-    // ==================== Expression Building ====================
-
-    /// Build IR for an expression, returning the result VarId
     fn build_expr(&mut self, expr: &Expr) -> Result<VarId> {
         match &expr.kind {
             ExprKind::Literal(lit) => self.build_literal(lit),

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -76,26 +76,17 @@ impl fmt::Display for MethodId {
 /// IR type representation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IrType {
-    /// Void type (no value)
     Void,
-    /// Boolean (1-bit integer)
     Bool,
-    /// 64-bit signed integer
     Int,
-    /// 64-bit floating point
     Float,
-    /// Pointer to string data
     String,
-    /// Pointer to a type
     Ptr(Box<IrType>),
-    /// Fixed-size array
     Array(Box<IrType>, usize),
-    /// Function type
     Function {
         params: Vec<IrType>,
         ret: Box<IrType>,
     },
-    /// Struct/class type
     Struct(ClassId),
 }
 
@@ -127,16 +118,11 @@ impl fmt::Display for IrType {
 /// Constant values in IR
 #[derive(Debug, Clone, PartialEq)]
 pub enum Constant {
-    /// Null pointer
     Null,
-    /// Boolean constant
     Bool(bool),
-    /// Integer constant
     Int(i64),
-    /// Float constant
     Float(f64),
-    /// String constant (index into string table)
-    String(u32),
+    String(u32), // index into string table
 }
 
 impl fmt::Display for Constant {
@@ -154,27 +140,20 @@ impl fmt::Display for Constant {
 /// Binary operation types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinaryOp {
-    // Arithmetic
     Add,
     Sub,
     Mul,
     Div,
     Mod,
     Pow,
-
-    // Comparison
     Eq,
     Ne,
     Lt,
     Le,
     Gt,
     Ge,
-
-    // Logical
     And,
     Or,
-
-    // Bitwise
     BitAnd,
     BitOr,
     BitXor,
@@ -211,11 +190,8 @@ impl fmt::Display for BinaryOp {
 /// Unary operation types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
-    /// Arithmetic negation
     Neg,
-    /// Logical not
     Not,
-    /// Bitwise not
     BitNot,
 }
 
@@ -229,14 +205,9 @@ impl fmt::Display for UnaryOp {
     }
 }
 
-/// IR Instructions
-///
-/// Each instruction operates on virtual registers (VarId) and produces
-/// a result in SSA form.
+/// IR Instructions in SSA form
 #[derive(Debug, Clone, PartialEq)]
 pub enum Instruction {
-    // ==================== Constants ====================
-    /// Load a constant value into a register
     /// dest = const value
     Const {
         dest: VarId,
@@ -244,8 +215,7 @@ pub enum Instruction {
         ty: IrType,
     },
 
-    // ==================== Arithmetic ====================
-    /// Binary operation: dest = left op right
+    /// dest = left op right
     Binary {
         dest: VarId,
         op: BinaryOp,
@@ -254,7 +224,7 @@ pub enum Instruction {
         ty: IrType,
     },
 
-    /// Unary operation: dest = op operand
+    /// dest = op operand
     Unary {
         dest: VarId,
         op: UnaryOp,
@@ -262,49 +232,53 @@ pub enum Instruction {
         ty: IrType,
     },
 
-    // ==================== Type Conversion ====================
-    /// Convert integer to float
-    IntToFloat { dest: VarId, src: VarId },
-
-    /// Convert float to integer
-    FloatToInt { dest: VarId, src: VarId },
-
-    /// Convert any value to string
-    ToString { dest: VarId, src: VarId },
-
-    /// Bitcast (reinterpret bits)
+    IntToFloat {
+        dest: VarId,
+        src: VarId,
+    },
+    FloatToInt {
+        dest: VarId,
+        src: VarId,
+    },
+    ToString {
+        dest: VarId,
+        src: VarId,
+    },
     Bitcast {
         dest: VarId,
         src: VarId,
         to_ty: IrType,
     },
 
-    // ==================== Memory ====================
-    /// Allocate stack space for a local variable
     /// dest = alloca ty
-    Alloca { dest: VarId, ty: IrType },
+    Alloca {
+        dest: VarId,
+        ty: IrType,
+    },
 
-    /// Load a value from memory
     /// dest = load ptr
-    Load { dest: VarId, ptr: VarId, ty: IrType },
+    Load {
+        dest: VarId,
+        ptr: VarId,
+        ty: IrType,
+    },
 
-    /// Store a value to memory
     /// store value -> ptr
-    Store { ptr: VarId, value: VarId },
+    Store {
+        ptr: VarId,
+        value: VarId,
+    },
 
-    /// Load a value from a global variable
-    /// dest = global_load @name
     GlobalLoad {
         dest: VarId,
         name: String,
         ty: IrType,
     },
+    GlobalStore {
+        name: String,
+        value: VarId,
+    },
 
-    /// Store a value to a global variable
-    /// global_store @name, value
-    GlobalStore { name: String, value: VarId },
-
-    /// Get pointer to array element
     /// dest = gep ptr, index
     GetElementPtr {
         dest: VarId,
@@ -313,11 +287,10 @@ pub enum Instruction {
         elem_ty: IrType,
     },
 
-    // ==================== Control Flow ====================
-    /// Unconditional jump
-    Jump { target: BlockId },
+    Jump {
+        target: BlockId,
+    },
 
-    /// Conditional branch
     /// if cond goto then_block else goto else_block
     Branch {
         cond: VarId,
@@ -325,11 +298,10 @@ pub enum Instruction {
         else_block: BlockId,
     },
 
-    /// Return from function
-    Return { value: Option<VarId> },
+    Return {
+        value: Option<VarId>,
+    },
 
-    // ==================== Function Calls ====================
-    /// Call a function
     /// dest = call func(args...)
     Call {
         dest: Option<VarId>,
@@ -338,7 +310,6 @@ pub enum Instruction {
         ret_ty: IrType,
     },
 
-    /// Call an indirect function (function pointer)
     CallIndirect {
         dest: Option<VarId>,
         func_ptr: VarId,
@@ -346,12 +317,12 @@ pub enum Instruction {
         ret_ty: IrType,
     },
 
-    // ==================== Objects ====================
-    /// Allocate a new object
     /// dest = new class
-    NewObject { dest: VarId, class: ClassId },
+    NewObject {
+        dest: VarId,
+        class: ClassId,
+    },
 
-    /// Get field from object
     /// dest = obj.field
     GetField {
         dest: VarId,
@@ -360,7 +331,6 @@ pub enum Instruction {
         ty: IrType,
     },
 
-    /// Set field on object
     /// obj.field = value
     SetField {
         object: VarId,
@@ -368,7 +338,6 @@ pub enum Instruction {
         value: VarId,
     },
 
-    /// Call a method on an object
     /// dest = obj.method(args...)
     CallMethod {
         dest: Option<VarId>,
@@ -378,7 +347,7 @@ pub enum Instruction {
         ret_ty: IrType,
     },
 
-    /// Call virtual method (through vtable)
+    /// Call through vtable
     CallVirtual {
         dest: Option<VarId>,
         object: VarId,
@@ -387,68 +356,49 @@ pub enum Instruction {
         ret_ty: IrType,
     },
 
-    // ==================== Arrays ====================
-    /// Create a new array
-    /// dest = array [elements...]
     NewArray {
         dest: VarId,
         elem_ty: IrType,
         elements: Vec<VarId>,
     },
-
-    /// Get array length
-    /// dest = len(array)
-    ArrayLen { dest: VarId, array: VarId },
-
-    /// Get array element
-    /// dest = array[index]
+    ArrayLen {
+        dest: VarId,
+        array: VarId,
+    },
     ArrayGet {
         dest: VarId,
         array: VarId,
         index: VarId,
         elem_ty: IrType,
     },
-
-    /// Set array element
-    /// array[index] = value
     ArraySet {
         array: VarId,
         index: VarId,
         value: VarId,
     },
-
-    /// Push element to array (append)
-    /// array.push(value)
     ArrayPush {
         array: VarId,
         value: VarId,
         elem_ty: IrType,
     },
 
-    // ==================== Strings ====================
-    /// Concatenate strings
-    /// dest = left + right
     StringConcat {
         dest: VarId,
         left: VarId,
         right: VarId,
     },
 
-    // ==================== Exception Handling ====================
-    /// Begin try block (marks exception handling region)
-    TryBegin { catch_block: BlockId },
-
-    /// End try block
+    TryBegin {
+        catch_block: BlockId,
+    },
     TryEnd,
+    Throw {
+        exception: VarId,
+    },
+    GetException {
+        dest: VarId,
+    },
 
-    /// Throw an exception
-    Throw { exception: VarId },
-
-    /// Get current exception in catch block
-    GetException { dest: VarId },
-
-    // ==================== Phi Functions (SSA) ====================
-    /// Phi function for SSA form
     /// dest = phi [val1, block1], [val2, block2], ...
     Phi {
         dest: VarId,
@@ -456,11 +406,9 @@ pub enum Instruction {
         incoming: Vec<(VarId, BlockId)>,
     },
 
-    // ==================== Debug/Intrinsics ====================
-    /// Print a value (for debugging/اطبع)
-    Print { value: VarId },
-
-    /// No operation (placeholder)
+    Print {
+        value: VarId,
+    }, // اطبع
     Nop,
 }
 

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -62,32 +62,26 @@ impl Lexer {
 
         let c = self.advance();
 
-        // Check for newlines
         if c == '\n' {
             return self.make_token(TokenKind::Newline);
         }
 
-        // Numbers (including Arabic-Indic numerals)
         if self.is_digit(c) {
             return self.scan_number(c);
         }
 
-        // Check for English letters - produce helpful error
         if self.is_english_letter(c) {
             return self.scan_english_identifier_error(c);
         }
 
-        // Identifiers and keywords (Arabic only)
         if self.is_identifier_start(c) {
             return self.scan_identifier(c);
         }
 
-        // Strings
         if c == '"' || c == '\'' || c == '«' {
             return self.scan_string(c);
         }
 
-        // Operators and punctuation
         self.scan_operator(c)
     }
 
@@ -104,8 +98,6 @@ impl Lexer {
         }
         tokens
     }
-
-    // ============ Helper Methods ============
 
     fn is_at_end(&self) -> bool {
         self.position >= self.source.len()
@@ -180,8 +172,6 @@ impl Lexer {
             self.current_lexeme(),
         )
     }
-
-    // ============ Character Classification ============
 
     fn is_digit(&self, c: char) -> bool {
         c.is_ascii_digit() || self.is_arabic_digit(c)
@@ -258,8 +248,6 @@ impl Lexer {
             '\u{FE70}'..='\u{FEFF}'    // Arabic Presentation Forms-B
         )
     }
-
-    // ============ Whitespace and Comments ============
 
     /// Skip whitespace and regular comments, but return doc comments as tokens
     /// Returns Some(Token) if a doc comment was found, None otherwise
@@ -436,13 +424,10 @@ impl Lexer {
         self.make_token(TokenKind::BlockDocComment(cleaned))
     }
 
-    // ============ Token Scanners ============
-
     fn scan_number(&mut self, first: char) -> Token {
         let mut value: i64 = self.digit_value(first) as i64;
         let mut overflowed = false;
 
-        // Consume integer part using checked arithmetic
         while !self.is_at_end() && self.is_digit(self.peek()) {
             let c = self.advance();
             let digit = self.digit_value(c) as i64;
@@ -456,7 +441,6 @@ impl Lexer {
             }
         }
 
-        // Check for decimal point
         if self.peek() == '.' && self.is_digit(self.peek_next()) {
             self.advance(); // consume '.'
 
@@ -469,11 +453,9 @@ impl Lexer {
                 divisor *= 10.0;
             }
 
-            // For floats, overflow is less critical - the value gets large but doesn't crash
             return self.make_token(TokenKind::FloatLiteral(value as f64 + fraction));
         }
 
-        // Check for exponent
         if self.peek() == 'e' || self.peek() == 'E' {
             self.advance();
 
@@ -495,7 +477,6 @@ impl Lexer {
             return self.make_token(TokenKind::FloatLiteral(float_val));
         }
 
-        // If integer overflowed, report error
         if overflowed {
             return self.make_token(TokenKind::Error(
                 "Integer literal too large / العدد الصحيح كبير جداً".to_string(),
@@ -513,7 +494,6 @@ impl Lexer {
             ident.push(self.advance());
         }
 
-        // Check if it's a keyword
         if let Some(keyword) = lookup_keyword(&ident) {
             self.make_token(keyword)
         } else {
@@ -587,7 +567,6 @@ impl Lexer {
 
     fn scan_operator(&mut self, c: char) -> Token {
         match c {
-            // Single-character tokens
             '(' => self.make_token(TokenKind::LeftParen),
             ')' => self.make_token(TokenKind::RightParen),
             '{' => self.make_token(TokenKind::LeftBrace),
@@ -597,16 +576,10 @@ impl Lexer {
             '.' => self.make_token(TokenKind::Dot),
             ':' => self.make_token(TokenKind::Colon),
             '?' => self.make_token(TokenKind::Question),
-
-            // Comma (ASCII and Arabic)
             ',' => self.make_token(TokenKind::Comma),
-            '،' => self.make_token(TokenKind::ArabicComma),
-
-            // Semicolon (ASCII and Arabic)
+            '،' => self.make_token(TokenKind::ArabicComma), // Arabic comma
             ';' => self.make_token(TokenKind::Semicolon),
-            '؛' => self.make_token(TokenKind::ArabicSemicolon),
-
-            // Two-character operators
+            '؛' => self.make_token(TokenKind::ArabicSemicolon), // Arabic semicolon
             '+' => {
                 if self.match_char('+') {
                     self.make_token(TokenKind::PlusPlus)

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -259,8 +259,6 @@ impl Parser {
         ))
     }
 
-    // ============ Declaration Parsing ============
-
     fn parse_declaration(&mut self) -> Result<Stmt, Diagnostic> {
         // Capture any doc comment before the declaration
         let doc_comment = self.consume_doc_comment();
@@ -870,8 +868,6 @@ impl Parser {
         Ok(Stmt::new(StmtKind::Export(Box::new(stmt)), span))
     }
 
-    // ============ Statement Parsing ============
-
     fn parse_statement(&mut self) -> Result<Stmt, Diagnostic> {
         if self.check(&TokenKind::If) {
             self.parse_if_statement()
@@ -1234,8 +1230,6 @@ impl Parser {
         let span = start.merge(&self.previous_span());
         Ok(Block::new(statements, span))
     }
-
-    // ============ Expression Parsing (Pratt Parser) ============
 
     fn parse_expression(&mut self) -> Result<Expr, Diagnostic> {
         self.parse_precedence(Precedence::Assignment)
@@ -1660,8 +1654,6 @@ impl Parser {
         Ok(args)
     }
 
-    // ============ Type Parsing ============
-
     fn parse_type_annotation(&mut self) -> Result<TypeAnnotation, Diagnostic> {
         let start = self.current_span();
 
@@ -1736,8 +1728,6 @@ impl Parser {
 
         Ok(params)
     }
-
-    // ============ Arrow Function Parsing ============
 
     /// Try to parse an arrow function starting after '('.
     /// Returns Some(Lambda) if successful, None if this is not an arrow function.
@@ -1846,8 +1836,6 @@ impl Parser {
             }
         }
     }
-
-    // ============ Helper Methods ============
 
     fn is_at_end(&self) -> bool {
         self.peek().kind == TokenKind::Eof
@@ -2275,8 +2263,6 @@ mod tests {
         assert!(ast.has_file_markers());
         assert_eq!(ast.statements.len(), 0);
     }
-
-    // ============ Enum Tests ============
 
     #[test]
     fn test_simple_enum() {


### PR DESCRIPTION
- Add .claude/rules/comments.md defining when to use comments (explain WHY not WHAT, following the "الوصف لا الترجمة" principle)
- Update rust-style.md to reference the new comments rule
- Remove ASCII art section headers from lexer, parser, IR files
- Remove redundant comments that just restate what code does
- Keep valuable comments explaining design decisions, SSA format, and Arabic language constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive code comment philosophy guide
  * Updated style guidelines with design principles and bilingual examples

* **Refactor**
  * Restructured instruction definitions for improved code clarity
  * Enhanced internal compiler representation with new instruction variants for global storage and exception handling
  * Cleaned up organizational comments across the codebase

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->