### PR TITLE
fix(parser): extend line comment handling to interfaces, enums, and match

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -606,6 +606,12 @@ impl Parser {
 
         let mut methods = Vec::new();
         while !self.check(&TokenKind::RightBrace) && !self.is_at_end() {
+            // Skip any line comments before the method
+            self.collect_line_comments();
+            if self.check(&TokenKind::RightBrace) {
+                self.take_pending_comments();
+                break;
+            }
             let method_doc = self.consume_doc_comment();
 
             self.expect(&TokenKind::Function, "Expected 'function'", "متوقع 'دالة'")?;
@@ -654,6 +660,12 @@ impl Parser {
 
         let mut variants = Vec::new();
         while !self.check(&TokenKind::RightBrace) && !self.is_at_end() {
+            // Skip any line comments before the variant
+            self.collect_line_comments();
+            if self.check(&TokenKind::RightBrace) {
+                self.take_pending_comments();
+                break;
+            }
             let variant = self.parse_enum_variant()?;
             variants.push(variant);
 
@@ -991,6 +1003,12 @@ impl Parser {
 
         let mut arms = Vec::new();
         while !self.check(&TokenKind::RightBrace) && !self.is_at_end() {
+            // Skip any line comments before the arm
+            self.collect_line_comments();
+            if self.check(&TokenKind::RightBrace) {
+                self.take_pending_comments();
+                break;
+            }
             match self.parse_match_arm() {
                 Ok(arm) => arms.push(arm),
                 Err(diagnostic) => {


### PR DESCRIPTION
## Summary

- Extends line comment handling to interface methods, enum variants, and match arms
- Prevents parse errors when line comments appear inside these constructs
- Cherry-picked from PR #89's parser improvements while keeping PR #88's architecturally correct IR implementation

## Changes

Added `collect_line_comments()` calls in:
- `parse_interface_declaration`: handles comments between interface methods
- `parse_enum_declaration`: handles comments between enum variants
- `parse_match_statement`: handles comments between match arms

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test` - all 41 tests pass
- [x] `cargo clippy` - no warnings

## Context

This is a follow-up to PR #88 which fixed property accessors. PR #89 had more comprehensive parser changes but used incorrect IR instructions. This PR cherry-picks just the useful parser improvements from #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment handling during parsing to ensure comments are properly collected and attached to interface methods, enum variants, and match arms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->