### PR TITLE
Add trailing comments feature

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Run benchmarks on PR branch
         id: bench_pr
         run: |
+          set -o pipefail  # Make pipeline fail if any command fails
           echo "Running benchmarks on PR branch..."
           mkdir -p benchmark-results
           if cargo bench -- --save-baseline pr 2>&1 | tee benchmark-pr.log; then
@@ -56,6 +57,7 @@ jobs:
         id: bench_base
         continue-on-error: true  # Base branch may not have benchmarks or may have different structure
         run: |
+          set -o pipefail  # Make pipeline fail if any command fails
           echo "Running benchmarks on base branch (${{ github.base_ref }})..."
           # Check if benchmarks exist in base branch
           if [ ! -f "Cargo.toml" ] || ! grep -q '\[\[bench\]\]' Cargo.toml 2>/dev/null; then

--- a/src/jit/optimizing/mod.rs
+++ b/src/jit/optimizing/mod.rs
@@ -31,4 +31,15 @@ impl OptimizingCompiler {
             "Optimizing JIT requires 'jit' feature",
         ))
     }
+
+    /// Stub compile method when JIT is disabled
+    pub fn compile(
+        &mut self,
+        _module: &crate::ir::Module,
+        _func: &crate::ir::Function,
+    ) -> Result<crate::jit::cache::CompiledFunction, crate::jit::error::JitError> {
+        Err(crate::jit::error::JitError::not_available(
+            "Optimizing JIT requires 'jit' feature",
+        ))
+    }
 }


### PR DESCRIPTION
Root cause analysis found several issues:
1. critcmp was looking in target/criterion for baselines but workflow checked benchmark-results/ directories instead
2. Silent failures masked by || echo patterns hid actual errors
3. No debugging output to diagnose failures

Changes:
- Add proper baseline detection by checking target/criterion/<group>/pr and target/criterion/<group>/base directories
- Add benchmark logs (benchmark-pr.log, benchmark-base.log) for debugging
- Check if base branch has benchmark configuration before running
- Add debug info section to show criterion directory contents
- Include benchmark logs in PR comment when no benchmarks found
- Upload log files as artifacts for debugging
- Add GitHub Actions warnings when benchmarks fail

This should reveal the actual cause of benchmark failures in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when attempting to use JIT compilation without the required feature enabled.

* **Chores**
  * Enhanced CI/CD pipeline robustness with improved error handling and logging for benchmark workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->