### PR TITLE
fix(ci): Replace deprecated release actions with softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,29 +13,227 @@ env:
 
 jobs:
   # ============================================
+  # Build Linux (x86_64)
+  # ============================================
+  build-linux-x86_64:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Strip binary
+        run: strip target/x86_64-unknown-linux-gnu/release/tarqeem
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/x86_64-unknown-linux-gnu/release/tarqeem dist/
+          cp README.md LICENSE dist/ 2>/dev/null || true
+          cd dist && tar -czvf ../tarqeem-linux-x86_64.tar.gz *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarqeem-linux-x86_64
+          path: tarqeem-linux-x86_64.tar.gz
+
+  # ============================================
+  # Build Linux (ARM64)
+  # ============================================
+  build-linux-aarch64:
+    name: Build Linux ARM64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: |
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          cargo build --release --target aarch64-unknown-linux-gnu
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+
+      - name: Strip binary
+        run: aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/tarqeem
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/aarch64-unknown-linux-gnu/release/tarqeem dist/
+          cp README.md LICENSE dist/ 2>/dev/null || true
+          cd dist && tar -czvf ../tarqeem-linux-aarch64.tar.gz *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarqeem-linux-aarch64
+          path: tarqeem-linux-aarch64.tar.gz
+
+  # ============================================
+  # Build macOS (x86_64)
+  # ============================================
+  build-macos-x86_64:
+    name: Build macOS x86_64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --target x86_64-apple-darwin
+
+      - name: Strip binary
+        run: strip target/x86_64-apple-darwin/release/tarqeem
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/x86_64-apple-darwin/release/tarqeem dist/
+          cp README.md LICENSE dist/ 2>/dev/null || true
+          cd dist && tar -czvf ../tarqeem-macos-x86_64.tar.gz *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarqeem-macos-x86_64
+          path: tarqeem-macos-x86_64.tar.gz
+
+  # ============================================
+  # Build macOS (ARM64 / Apple Silicon)
+  # ============================================
+  build-macos-aarch64:
+    name: Build macOS ARM64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --target aarch64-apple-darwin
+
+      - name: Strip binary
+        run: strip target/aarch64-apple-darwin/release/tarqeem
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/aarch64-apple-darwin/release/tarqeem dist/
+          cp README.md LICENSE dist/ 2>/dev/null || true
+          cd dist && tar -czvf ../tarqeem-macos-aarch64.tar.gz *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarqeem-macos-aarch64
+          path: tarqeem-macos-aarch64.tar.gz
+
+  # ============================================
+  # Build Windows (x86_64)
+  # ============================================
+  build-windows-x86_64:
+    name: Build Windows x86_64
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Package
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist
+          Copy-Item target/x86_64-pc-windows-msvc/release/tarqeem.exe dist/
+          if (Test-Path README.md) { Copy-Item README.md dist/ }
+          if (Test-Path LICENSE) { Copy-Item LICENSE dist/ }
+          Compress-Archive -Path dist/* -DestinationPath tarqeem-windows-x86_64.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarqeem-windows-x86_64
+          path: tarqeem-windows-x86_64.zip
+
+  # ============================================
   # Create GitHub Release
   # ============================================
-  create-release:
+  release:
     name: Create Release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ steps.get_version.outputs.version }}
+    needs:
+      - build-linux-x86_64
+      - build-linux-aarch64
+      - build-macos-x86_64
+      - build-macos-aarch64
+      - build-windows-x86_64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Get version from tag
-        id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release-files
+          mv artifacts/tarqeem-linux-x86_64/tarqeem-linux-x86_64.tar.gz release-files/
+          mv artifacts/tarqeem-linux-aarch64/tarqeem-linux-aarch64.tar.gz release-files/
+          mv artifacts/tarqeem-macos-x86_64/tarqeem-macos-x86_64.tar.gz release-files/
+          mv artifacts/tarqeem-macos-aarch64/tarqeem-macos-aarch64.tar.gz release-files/
+          mv artifacts/tarqeem-windows-x86_64/tarqeem-windows-x86_64.zip release-files/
+          ls -la release-files/
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Tarqeem ${{ github.ref_name }}
+          name: Tarqeem ${{ github.ref_name }}
           body: |
             ## Tarqeem ${{ github.ref_name }}
 
@@ -77,221 +275,12 @@ jobs:
 
             ### What's New
             See [CHANGELOG.md](https://github.com/osama1998H/tarqeem/blob/main/CHANGELOG.md) for details.
+          files: release-files/*
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
-
-  # ============================================
-  # Build Linux (x86_64)
-  # ============================================
-  build-linux-x86_64:
-    name: Build Linux x86_64
-    runs-on: ubuntu-latest
-    needs: create-release
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-gnu
-
-      - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release --target x86_64-unknown-linux-gnu
-
-      - name: Strip binary
-        run: strip target/x86_64-unknown-linux-gnu/release/tarqeem
-
-      - name: Package
-        run: |
-          mkdir -p dist
-          cp target/x86_64-unknown-linux-gnu/release/tarqeem dist/
-          cp README.md LICENSE dist/ 2>/dev/null || true
-          cd dist && tar -czvf ../tarqeem-linux-x86_64.tar.gz *
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./tarqeem-linux-x86_64.tar.gz
-          asset_name: tarqeem-linux-x86_64.tar.gz
-          asset_content_type: application/gzip
-
-  # ============================================
-  # Build Linux (ARM64)
-  # ============================================
-  build-linux-aarch64:
-    name: Build Linux ARM64
-    runs-on: ubuntu-latest
-    needs: create-release
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-unknown-linux-gnu
-
-      - name: Install cross-compilation tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: |
-          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-          cargo build --release --target aarch64-unknown-linux-gnu
-        env:
-          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
-
-      - name: Strip binary
-        run: aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/tarqeem
-
-      - name: Package
-        run: |
-          mkdir -p dist
-          cp target/aarch64-unknown-linux-gnu/release/tarqeem dist/
-          cp README.md LICENSE dist/ 2>/dev/null || true
-          cd dist && tar -czvf ../tarqeem-linux-aarch64.tar.gz *
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./tarqeem-linux-aarch64.tar.gz
-          asset_name: tarqeem-linux-aarch64.tar.gz
-          asset_content_type: application/gzip
-
-  # ============================================
-  # Build macOS (x86_64)
-  # ============================================
-  build-macos-x86_64:
-    name: Build macOS x86_64
-    runs-on: macos-latest
-    needs: create-release
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-apple-darwin
-
-      - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release --target x86_64-apple-darwin
-
-      - name: Strip binary
-        run: strip target/x86_64-apple-darwin/release/tarqeem
-
-      - name: Package
-        run: |
-          mkdir -p dist
-          cp target/x86_64-apple-darwin/release/tarqeem dist/
-          cp README.md LICENSE dist/ 2>/dev/null || true
-          cd dist && tar -czvf ../tarqeem-macos-x86_64.tar.gz *
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./tarqeem-macos-x86_64.tar.gz
-          asset_name: tarqeem-macos-x86_64.tar.gz
-          asset_content_type: application/gzip
-
-  # ============================================
-  # Build macOS (ARM64 / Apple Silicon)
-  # ============================================
-  build-macos-aarch64:
-    name: Build macOS ARM64
-    runs-on: macos-latest
-    needs: create-release
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
-
-      - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release --target aarch64-apple-darwin
-
-      - name: Strip binary
-        run: strip target/aarch64-apple-darwin/release/tarqeem
-
-      - name: Package
-        run: |
-          mkdir -p dist
-          cp target/aarch64-apple-darwin/release/tarqeem dist/
-          cp README.md LICENSE dist/ 2>/dev/null || true
-          cd dist && tar -czvf ../tarqeem-macos-aarch64.tar.gz *
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./tarqeem-macos-aarch64.tar.gz
-          asset_name: tarqeem-macos-aarch64.tar.gz
-          asset_content_type: application/gzip
-
-  # ============================================
-  # Build Windows (x86_64)
-  # ============================================
-  build-windows-x86_64:
-    name: Build Windows x86_64
-    runs-on: windows-latest
-    needs: create-release
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-msvc
-
-      - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release --target x86_64-pc-windows-msvc
-
-      - name: Package
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path dist
-          Copy-Item target/x86_64-pc-windows-msvc/release/tarqeem.exe dist/
-          if (Test-Path README.md) { Copy-Item README.md dist/ }
-          if (Test-Path LICENSE) { Copy-Item LICENSE dist/ }
-          Compress-Archive -Path dist/* -DestinationPath tarqeem-windows-x86_64.zip
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./tarqeem-windows-x86_64.zip
-          asset_name: tarqeem-windows-x86_64.zip
-          asset_content_type: application/zip
 
   # ============================================
   # Update Homebrew Formula (Optional)
@@ -299,7 +288,7 @@ jobs:
   # update-homebrew:
   #   name: Update Homebrew
   #   runs-on: ubuntu-latest
-  #   needs: [build-macos-x86_64, build-macos-aarch64]
+  #   needs: release
   #   steps:
   #     - name: Update Homebrew formula
   #       run: echo "TODO: Implement Homebrew formula update"
@@ -310,9 +299,9 @@ jobs:
   # publish-crates:
   #   name: Publish to crates.io
   #   runs-on: ubuntu-latest
-  #   needs: create-release
+  #   needs: release
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@v4
   #     - uses: dtolnay/rust-toolchain@stable
   #     - name: Publish
   #       run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes the release workflow that was failing with `"Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}"` error
- Replaces deprecated `actions/create-release@v1` and `actions/upload-release-asset@v1` (both archived since 2020)
- Fixes `actions/checkout@v6` to `v4` (v6 doesn't exist)

## Root Cause

The workflow failed because:
1. User manually created a release for v0.1.0 via GitHub UI
2. The tag push triggered the workflow
3. The deprecated `actions/create-release@v1` tried to create another release with the same tag
4. GitHub rejected the duplicate release

## Changes

- Uses `softprops/action-gh-release@v2` which handles existing releases gracefully
- Build jobs now upload artifacts using `actions/upload-artifact@v4`
- Single `release` job downloads all artifacts and creates the release in one step
- This prevents race conditions and makes the workflow idempotent

## Test plan

- [ ] Delete the existing v0.1.0 release or create a new test tag (e.g., v0.1.1)
- [ ] Merge this PR and push the tag
- [ ] Verify the release is created with all 5 platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)