### PR TITLE
fix(lsp): add entry point mode conflict detection to LSP

### DIFF
--- a/src/lsp/analysis/document.rs
+++ b/src/lsp/analysis/document.rs
@@ -237,7 +237,6 @@ impl DocumentState {
     }
 
     fn collect_symbols(&self, ast: &Ast, symbols: &mut HashMap<String, SymbolInfo>) {
-
         for stmt in &ast.statements {
             match &stmt.kind {
                 StmtKind::VarDecl {


### PR DESCRIPTION
## Summary

- Fix LSP not showing error `ت٠٢٠١` when code has both Script mode and Program mode
- Add `check_entry_point_conflict()` validation to LSP document analysis
- Error now appears in editor with proper span and helpful note

## Problem

The editor wasn't showing error `ت٠٢٠١` (Entry Point Mode Conflict) when code contained both:
- Top-level executable statements (Script mode)
- `دالة رئيسية()` function (Program mode)

## Root Cause

The LSP pipeline only ran:
```
Source → Lexer → Parser → Semantic ← STOPPED HERE
```

But the entry point conflict validation was in the IR builder:
```
Source → Lexer → Parser → Semantic → IR Builder ← VALIDATION HERE
```

## Solution

Added the same validation logic directly to the LSP's `document.rs`:
- Detects `دالة رئيسية()` declaration
- Detects first top-level executable statement
- Returns error `ت٠٢٠١` if both exist
- Points error at `دالة رئيسية()` with note showing where executable code is

## Test plan

- [x] Build passes (`cargo build --release`)
- [x] All tests pass (`cargo test`)
- [x] Verified in Qalam editor - error now shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects conflicting entry points when a primary function and top-level executable statements coexist in the same file; shows a clear diagnostic anchored to the primary function with a pointer to the first executable statement and bilingual messaging to help resolve the conflict.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->