### PR TITLE
fix(fmt): preserve // comments during LSP formatting

### DIFF
--- a/src/lsp/handlers/formatting.rs
+++ b/src/lsp/handlers/formatting.rs
@@ -161,6 +161,14 @@ fn format_line(line: &str) -> String {
                 chars.next();
                 ensure_space_after(&mut result, &mut chars);
             }
+            '/' if chars.peek() == Some(&'/') => {
+                // Line comment - preserve the rest of the line as-is
+                result.push_str("//");
+                chars.next();
+                for remaining in chars.by_ref() {
+                    result.push(remaining);
+                }
+            }
             '+' | '-' | '*' | '/' | '%' | '=' => {
                 ensure_space_before(&mut result);
                 result.push(c);


### PR DESCRIPTION
## Summary

- Fix formatter corrupting `//` comments to `/ /` during LSP formatting
- Comments are now preserved correctly in the Qalam editor

## Problem

When formatting code in the Qalam editor, single-line comments were being corrupted:

```tarqeem
// Before formatting
متغير س = 5 // تعليق

// After formatting (BROKEN)
متغير س = 5 / / تعليق
```

## Root Cause

In `src/lsp/handlers/formatting.rs`, the `format_line()` function treated `/` as a division operator and added spaces around it (line 164):

```rust
'+' | '-' | '*' | '/' | '%' | '=' => {
    ensure_space_before(&mut result);
    result.push(c);
    ensure_space_after(&mut result, &mut chars);
}
```

When processing `//`, each `/` was handled separately, resulting in `/ /`.

## Solution

Added a case to detect `//` (comment start) BEFORE the single `/` operator case:

```rust
'/' if chars.peek() == Some(&'/') => {
    // Line comment - preserve the rest of the line as-is
    result.push_str("//");
    chars.next();
    for remaining in chars.by_ref() {
        result.push(remaining);
    }
}
```

## Test plan

- [x] All formatting tests pass
- [x] Tested in Qalam editor - comments preserved after formatting
- [x] Code compiles successfully after formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)