### PR TITLE
feat(cli): add --profile flag for runtime profiling output

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -351,7 +351,7 @@ pub fn run(cli: Cli) -> Result<(), String> {
             compile(args, lang)
         }
 
-        Commands::Run { file, jit } => run_command(file, jit, cli.verbose, lang),
+        Commands::Run { file, jit, profile } => run_command(file, jit, profile, cli.verbose, lang),
 
         Commands::Debug {
             file,
@@ -405,7 +405,13 @@ pub fn run(cli: Cli) -> Result<(), String> {
 // Individual Command Implementations
 // ============================================================================
 
-fn run_command(file: PathBuf, jit: bool, verbose: bool, lang: Language) -> Result<(), String> {
+fn run_command(
+    file: PathBuf,
+    jit: bool,
+    profile: bool,
+    verbose: bool,
+    lang: Language,
+) -> Result<(), String> {
     warn_invalid_extension(&file);
 
     // Arabic-only: ترقيم لغة برمجة عربية
@@ -443,21 +449,27 @@ fn run_command(file: PathBuf, jit: bool, verbose: bool, lang: Language) -> Resul
         )
     })?;
 
-    if jit {
+    // When --profile is used, always use JIT for profiling data
+    let use_jit = jit || profile;
+
+    if use_jit {
         // Use JIT compilation
-        if verbose {
+        if verbose && !profile {
             println!(
                 "{}",
                 "Using JIT compilation / استخدام الترجمة الفورية".cyan()
             );
         }
 
-        let config = JitConfig::default().with_verbose(verbose);
+        let config = JitConfig::default().with_verbose(verbose && !profile);
         let mut executor = JitExecutor::new(ir_module, config);
 
         match executor.run() {
             Ok(_result) => {
-                if verbose {
+                if profile {
+                    // Output profiling data as JSON for IDE integration
+                    println!("{}", executor.profile_summary().to_json());
+                } else if verbose {
                     println!(
                         "{}",
                         "Program completed successfully (JIT) / اكتمل تنفيذ البرنامج بنجاح (ترجمة فورية)".green()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,6 +93,10 @@ pub enum Commands {
         /// Use JIT compilation instead of interpreter (experimental)
         #[arg(long, aliases = ["ترجمة_فورية"])]
         jit: bool,
+
+        /// Output profiling data as JSON (for IDE integration)
+        #[arg(long, aliases = ["تنميط"])]
+        profile: bool,
     },
 
     #[command(aliases = ["صحح", "dbg"])]

--- a/src/jit/profile.rs
+++ b/src/jit/profile.rs
@@ -444,6 +444,32 @@ pub struct ProfileSummary {
     pub hottest_functions: Vec<(String, u64)>,
 }
 
+impl ProfileSummary {
+    /// Output profiling data as JSON (for IDE integration)
+    pub fn to_json(&self) -> String {
+        let hot_spots_json: Vec<String> = self
+            .hottest_functions
+            .iter()
+            .map(|(name, calls)| format!(r#"{{"name":"{}","calls":{}}}"#, name, calls))
+            .collect();
+
+        let tiers_json: Vec<String> = self
+            .by_tier
+            .iter()
+            .map(|(tier, count)| format!(r#""{}": {}"#, tier.name_en(), count))
+            .collect();
+
+        format!(
+            r#"{{"total_functions":{},"total_calls":{},"tier_up_count":{},"hot_spots":[{}],"by_tier":{{{}}}}}"#,
+            self.total_functions,
+            self.total_calls,
+            self.tier_up_count,
+            hot_spots_json.join(","),
+            tiers_json.join(",")
+        )
+    }
+}
+
 impl std::fmt::Display for ProfileSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "JIT Profile Summary / ملخص التنميط الفوري")?;


### PR DESCRIPTION
## Summary

- Add `--profile` (`--تنميط`) flag to `tarqeem run` command
- Outputs profiling data as JSON for IDE integration
- Automatically enables JIT executor when profiling

### JSON Output Format

```json
{
  "total_functions": 1,
  "total_calls": 1,
  "tier_up_count": 0,
  "hot_spots": [{"name": "__main__", "calls": 1}],
  "by_tier": {"Interpreted": 1}
}
```

## Test plan

- [x] `tarqeem run --profile examples/مرحبا.ترقيم` outputs JSON profiling data
- [x] All existing tests pass
- [x] No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--profile` flag to capture profiling metrics during code execution
  * Profiling output is formatted as JSON for IDE integration
  * JIT compilation automatically enables when profiling is active

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->