### PR TITLE
feat(parser): add support for grouped exports

### DIFF
--- a/src/doc/extractor.rs
+++ b/src/doc/extractor.rs
@@ -381,7 +381,17 @@ impl DocExtractor {
                 Some(DocItem::Enum(enum_doc))
             }
 
-            StmtKind::Export(inner) => self.extract_stmt(inner, true),
+            StmtKind::Export(export_items) => {
+                use crate::parser::ExportItems;
+                match export_items {
+                    ExportItems::Declaration(inner) => self.extract_stmt(inner, true),
+                    // Named exports, wildcards, and re-exports don't have their own documentation
+                    // They re-export items documented elsewhere
+                    ExportItems::Named(_)
+                    | ExportItems::Wildcard { .. }
+                    | ExportItems::NamedReexport { .. } => None,
+                }
+            }
 
             _ => None,
         }

--- a/src/fmt/formatter.rs
+++ b/src/fmt/formatter.rs
@@ -414,10 +414,71 @@ impl Formatter {
                 p.write_char('"');
             }
 
-            StmtKind::Export(inner) => {
+            StmtKind::Export(export_items) => {
+                use crate::parser::ExportItems;
                 p.write("صدّر");
-                p.write_space();
-                self.format_stmt_inline(inner, p);
+                match export_items {
+                    ExportItems::Declaration(inner) => {
+                        p.write_space();
+                        self.format_stmt_inline(inner, p);
+                    }
+                    ExportItems::Named(items) => {
+                        p.write_space();
+                        p.write("{");
+                        p.write_space();
+                        for (i, item) in items.iter().enumerate() {
+                            if i > 0 {
+                                p.write_comma();
+                                p.write_space();
+                            }
+                            p.write(&item.name);
+                            if let Some(alias) = &item.alias {
+                                p.write_space();
+                                p.write("كـ");
+                                p.write_space();
+                                p.write(alias);
+                            }
+                        }
+                        p.write_space();
+                        p.write("}");
+                    }
+                    ExportItems::Wildcard { from } => {
+                        p.write_space();
+                        p.write("*");
+                        p.write_space();
+                        p.write("من");
+                        p.write_space();
+                        p.write("\"");
+                        p.write(from);
+                        p.write("\"");
+                    }
+                    ExportItems::NamedReexport { items, from } => {
+                        p.write_space();
+                        p.write("{");
+                        p.write_space();
+                        for (i, item) in items.iter().enumerate() {
+                            if i > 0 {
+                                p.write_comma();
+                                p.write_space();
+                            }
+                            p.write(&item.name);
+                            if let Some(alias) = &item.alias {
+                                p.write_space();
+                                p.write("كـ");
+                                p.write_space();
+                                p.write(alias);
+                            }
+                        }
+                        p.write_space();
+                        p.write("}");
+                        p.write_space();
+                        p.write("من");
+                        p.write_space();
+                        p.write("\"");
+                        p.write(from);
+                        p.write("\"");
+                    }
+                }
             }
 
             StmtKind::Expr(expr) => {

--- a/src/ir/builder/stmt_builder.rs
+++ b/src/ir/builder/stmt_builder.rs
@@ -83,7 +83,17 @@ impl IrBuilder {
             } => self.build_try(body, catch.as_ref(), finally.as_ref()),
             StmtKind::Throw(expr) => self.build_throw(expr),
             StmtKind::Import { .. } => Ok(()),
-            StmtKind::Export(inner) => self.build_stmt(inner),
+            StmtKind::Export(export_items) => {
+                use crate::parser::ExportItems;
+                match export_items {
+                    ExportItems::Declaration(inner) => self.build_stmt(inner),
+                    // Named exports, wildcards, and re-exports don't generate IR
+                    // They're module-level metadata handled during semantic analysis
+                    ExportItems::Named(_)
+                    | ExportItems::Wildcard { .. }
+                    | ExportItems::NamedReexport { .. } => Ok(()),
+                }
+            }
             StmtKind::Expr(expr) => {
                 self.build_expr(expr)?;
                 Ok(())

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -166,7 +166,7 @@ pub enum StmtKind {
         from: String,
     },
 
-    Export(Box<Stmt>),
+    Export(ExportItems),
 
     Expr(Expr),
 
@@ -461,6 +461,29 @@ pub enum ImportItems {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ImportItem {
+    pub name: String,
+    pub alias: Option<String>,
+}
+
+/// Export items for different export patterns.
+#[derive(Debug, Clone, Serialize)]
+pub enum ExportItems {
+    /// Export a declaration: صدّر دالة/صنف/ثابت
+    Declaration(Box<Stmt>),
+    /// Named exports: صدّر { name1، name2 }
+    Named(Vec<ExportItem>),
+    /// Wildcard re-export: صدّر * من "module"
+    Wildcard { from: String },
+    /// Named re-export: صدّر { name1، name2 } من "module"
+    NamedReexport {
+        items: Vec<ExportItem>,
+        from: String,
+    },
+}
+
+/// An individual export item with optional alias.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExportItem {
     pub name: String,
     pub alias: Option<String>,
 }

--- a/src/parser/parser/decl_parser.rs
+++ b/src/parser/parser/decl_parser.rs
@@ -653,13 +653,59 @@ impl Parser {
     }
 
     /// Parse an export statement.
+    ///
+    /// Supports:
+    /// - `صدّر دالة/صنف/ثابت...` - Declaration export
+    /// - `صدّر { name1، name2 }` - Named exports
+    /// - `صدّر { name1، name2 } من "module"` - Named re-exports
+    /// - `صدّر * من "module"` - Wildcard re-export
     pub(crate) fn parse_export_statement(&mut self) -> Result<Stmt, Diagnostic> {
         let start = self.current_span();
-        self.advance(); // consume 'export'
+        self.advance(); // consume 'export' (صدّر)
 
-        let stmt = self.parse_declaration()?;
+        let items = if self.match_token(&TokenKind::Star) {
+            // صدّر * من "module" - Wildcard re-export
+            self.expect(&TokenKind::From, "متوقع 'من' بعد '*' في التصدير")?;
+            let from = self.expect_string("متوقع مسار الوحدة")?;
+            ExportItems::Wildcard { from }
+        } else if self.match_token(&TokenKind::LeftBrace) {
+            // صدّر { name1، name2 } [من "module"]
+            let mut items = Vec::new();
+            loop {
+                let name = self.expect_identifier("متوقع اسم التصدير")?;
+                let alias = if self.match_token(&TokenKind::As) {
+                    Some(self.expect_identifier("متوقع الاسم المستعار")?)
+                } else {
+                    None
+                };
+                items.push(ExportItem { name, alias });
+
+                if !self.match_token(&TokenKind::Comma)
+                    && !self.match_token(&TokenKind::ArabicComma)
+                {
+                    break;
+                }
+            }
+            self.expect(&TokenKind::RightBrace, "متوقع '}'")?;
+
+            if self.match_token(&TokenKind::From) {
+                // Re-export from another module
+                let from = self.expect_string("متوقع مسار الوحدة")?;
+                ExportItems::NamedReexport { items, from }
+            } else {
+                // Export from current module
+                ExportItems::Named(items)
+            }
+        } else {
+            // صدّر دالة/صنف/ثابت... - Declaration export
+            let stmt = self.parse_declaration()?;
+            ExportItems::Declaration(Box::new(stmt))
+        };
+
+        self.consume_semicolon()?;
+
         let span = start.merge(&self.previous_span());
-        Ok(Stmt::new(StmtKind::Export(Box::new(stmt)), span))
+        Ok(Stmt::new(StmtKind::Export(items), span))
     }
 
     /// Parse a type annotation.

--- a/src/parser/parser_tests.rs
+++ b/src/parser/parser_tests.rs
@@ -359,11 +359,14 @@ fn test_parse_export_function() {
     let ast = parser.parse().unwrap();
 
     match &ast.statements[0].kind {
-        StmtKind::Export(inner) => match &inner.kind {
-            StmtKind::FuncDecl { name, .. } => {
-                assert_eq!(name, "مساعدة");
-            }
-            _ => panic!("Expected FuncDecl inside export"),
+        StmtKind::Export(export_items) => match export_items {
+            ExportItems::Declaration(inner) => match &inner.kind {
+                StmtKind::FuncDecl { name, .. } => {
+                    assert_eq!(name, "مساعدة");
+                }
+                _ => panic!("Expected FuncDecl inside export"),
+            },
+            _ => panic!("Expected Declaration export"),
         },
         _ => panic!("Expected Export statement"),
     }
@@ -382,11 +385,14 @@ fn test_parse_export_class() {
     let ast = parser.parse().unwrap();
 
     match &ast.statements[0].kind {
-        StmtKind::Export(inner) => match &inner.kind {
-            StmtKind::ClassDecl { name, .. } => {
-                assert_eq!(name, "مساعد");
-            }
-            _ => panic!("Expected ClassDecl inside export"),
+        StmtKind::Export(export_items) => match export_items {
+            ExportItems::Declaration(inner) => match &inner.kind {
+                StmtKind::ClassDecl { name, .. } => {
+                    assert_eq!(name, "مساعد");
+                }
+                _ => panic!("Expected ClassDecl inside export"),
+            },
+            _ => panic!("Expected Declaration export"),
         },
         _ => panic!("Expected Export statement"),
     }

--- a/src/semantic/analyzer/stmt_analyzer.rs
+++ b/src/semantic/analyzer/stmt_analyzer.rs
@@ -155,8 +155,8 @@ impl Analyzer {
                 self.analyze_import(items, from, stmt.span);
             }
 
-            StmtKind::Export(inner) => {
-                self.analyze_stmt(inner);
+            StmtKind::Export(export_items) => {
+                self.analyze_export(export_items, stmt.span);
             }
 
             StmtKind::Expr(expr) => {
@@ -1034,6 +1034,34 @@ impl Analyzer {
                     used: false,
                     span,
                 });
+            }
+        }
+    }
+
+    /// Analyze an export statement.
+    pub(crate) fn analyze_export(&mut self, export_items: &ExportItems, span: Span) {
+        match export_items {
+            ExportItems::Declaration(inner) => {
+                // صدّر دالة/صنف/ثابت... - analyze the inner declaration
+                self.analyze_stmt(inner);
+            }
+            ExportItems::Named(items) => {
+                // صدّر { name1، name2 } - verify names are defined
+                for item in items {
+                    if self.scope.lookup(&item.name).is_none() {
+                        self.warn(&format!("الاسم '{}' غير معرّف للتصدير", item.name), span);
+                    }
+                }
+            }
+            ExportItems::Wildcard { from: _ } => {
+                // صدّر * من "module" - re-export all from module
+                // Full validation requires loading the source module
+            }
+            ExportItems::NamedReexport { items, from: _ } => {
+                // صدّر { name1، name2 } من "module"
+                // Full validation requires loading the source module
+                // For now, just register that these are being re-exported
+                let _ = items; // Suppress unused warning
             }
         }
     }

--- a/src/semantic/modules.rs
+++ b/src/semantic/modules.rs
@@ -230,58 +230,98 @@ impl ModuleLoader {
     }
 
     fn collect_exports(&self, ast: &Ast) -> HashMap<String, ExportedSymbol> {
-        use crate::parser::StmtKind;
+        use crate::parser::{ExportItems, StmtKind};
 
         let mut exports = HashMap::new();
 
         for stmt in &ast.statements {
-            if let StmtKind::Export(inner) = &stmt.kind {
-                match &inner.kind {
-                    StmtKind::FuncDecl { name, .. } => {
-                        exports.insert(
-                            name.clone(),
-                            ExportedSymbol {
-                                name: name.clone(),
-                                kind: ExportKind::Function,
-                                span: stmt.span,
-                            },
-                        );
+            if let StmtKind::Export(export_items) = &stmt.kind {
+                match export_items {
+                    ExportItems::Declaration(inner) => {
+                        // Handle صدّر دالة/صنف/ثابت...
+                        match &inner.kind {
+                            StmtKind::FuncDecl { name, .. } => {
+                                exports.insert(
+                                    name.clone(),
+                                    ExportedSymbol {
+                                        name: name.clone(),
+                                        kind: ExportKind::Function,
+                                        span: stmt.span,
+                                    },
+                                );
+                            }
+                            StmtKind::ClassDecl { name, .. } => {
+                                exports.insert(
+                                    name.clone(),
+                                    ExportedSymbol {
+                                        name: name.clone(),
+                                        kind: ExportKind::Class,
+                                        span: stmt.span,
+                                    },
+                                );
+                            }
+                            StmtKind::InterfaceDecl { name, .. } => {
+                                exports.insert(
+                                    name.clone(),
+                                    ExportedSymbol {
+                                        name: name.clone(),
+                                        kind: ExportKind::Interface,
+                                        span: stmt.span,
+                                    },
+                                );
+                            }
+                            StmtKind::VarDecl { name, mutable, .. } => {
+                                exports.insert(
+                                    name.clone(),
+                                    ExportedSymbol {
+                                        name: name.clone(),
+                                        kind: if *mutable {
+                                            ExportKind::Variable
+                                        } else {
+                                            ExportKind::Constant
+                                        },
+                                        span: stmt.span,
+                                    },
+                                );
+                            }
+                            _ => {}
+                        }
                     }
-                    StmtKind::ClassDecl { name, .. } => {
-                        exports.insert(
-                            name.clone(),
-                            ExportedSymbol {
-                                name: name.clone(),
-                                kind: ExportKind::Class,
-                                span: stmt.span,
-                            },
-                        );
-                    }
-                    StmtKind::InterfaceDecl { name, .. } => {
-                        exports.insert(
-                            name.clone(),
-                            ExportedSymbol {
-                                name: name.clone(),
-                                kind: ExportKind::Interface,
-                                span: stmt.span,
-                            },
-                        );
-                    }
-                    StmtKind::VarDecl { name, mutable, .. } => {
-                        exports.insert(
-                            name.clone(),
-                            ExportedSymbol {
-                                name: name.clone(),
-                                kind: if *mutable {
-                                    ExportKind::Variable
-                                } else {
-                                    ExportKind::Constant
+                    ExportItems::Named(items) => {
+                        // Handle صدّر { name1، name2 }
+                        // These are re-exports of previously defined/imported symbols
+                        for item in items {
+                            let export_name = item.alias.as_ref().unwrap_or(&item.name);
+                            exports.insert(
+                                export_name.clone(),
+                                ExportedSymbol {
+                                    name: item.name.clone(),
+                                    kind: ExportKind::Variable, // Type determined later
+                                    span: stmt.span,
                                 },
-                                span: stmt.span,
-                            },
-                        );
+                            );
+                        }
                     }
-                    _ => {}
+                    ExportItems::Wildcard { from: _ } => {
+                        // Handle صدّر * من "module"
+                        // This re-exports all from another module
+                        // Full resolution requires loading that module
+                    }
+                    ExportItems::NamedReexport { items, from: _ } => {
+                        // Handle صدّر { name1، name2 } من "module"
+                        // Re-export specific names from another module
+                        for item in items {
+                            let export_name = item.alias.as_ref().unwrap_or(&item.name);
+                            exports.insert(
+                                export_name.clone(),
+                                ExportedSymbol {
+                                    name: item.name.clone(),
+                                    kind: ExportKind::Variable, // Type determined later
+                                    span: stmt.span,
+                                },
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src/semantic/modules.rs
+++ b/src/semantic/modules.rs
@@ -218,7 +218,7 @@ impl ModuleLoader {
             }
         };
 
-        let exports = self.collect_exports(&ast);
+        let exports = self.collect_exports(&ast, path);
 
         Ok(LoadedModule {
             id: ModuleId(path.to_path_buf()),
@@ -229,10 +229,18 @@ impl ModuleLoader {
         })
     }
 
-    fn collect_exports(&self, ast: &Ast) -> HashMap<String, ExportedSymbol> {
+    fn collect_exports(
+        &mut self,
+        ast: &Ast,
+        current_path: &Path,
+    ) -> HashMap<String, ExportedSymbol> {
         use crate::parser::{ExportItems, StmtKind};
 
         let mut exports = HashMap::new();
+
+        // First pass: collect direct exports and prepare re-export info
+        let mut wildcard_reexports: Vec<(String, Span)> = Vec::new();
+        let mut named_reexports: Vec<(Vec<crate::parser::ExportItem>, String, Span)> = Vec::new();
 
         for stmt in &ast.statements {
             if let StmtKind::Export(export_items) = &stmt.kind {
@@ -284,6 +292,16 @@ impl ModuleLoader {
                                     },
                                 );
                             }
+                            StmtKind::EnumDecl { name, .. } => {
+                                exports.insert(
+                                    name.clone(),
+                                    ExportedSymbol {
+                                        name: name.clone(),
+                                        kind: ExportKind::Class, // Enums are treated like classes
+                                        span: stmt.span,
+                                    },
+                                );
+                            }
                             _ => {}
                         }
                     }
@@ -302,22 +320,57 @@ impl ModuleLoader {
                             );
                         }
                     }
-                    ExportItems::Wildcard { from: _ } => {
+                    ExportItems::Wildcard { from } => {
                         // Handle صدّر * من "module"
-                        // This re-exports all from another module
-                        // Full resolution requires loading that module
+                        // Store for second pass to resolve after all modules loaded
+                        wildcard_reexports.push((from.clone(), stmt.span));
                     }
-                    ExportItems::NamedReexport { items, from: _ } => {
+                    ExportItems::NamedReexport { items, from } => {
                         // Handle صدّر { name1، name2 } من "module"
-                        // Re-export specific names from another module
-                        for item in items {
-                            let export_name = item.alias.as_ref().unwrap_or(&item.name);
+                        // Store for second pass
+                        named_reexports.push((items.clone(), from.clone(), stmt.span));
+                    }
+                }
+            }
+        }
+
+        // Second pass: resolve wildcard re-exports
+        for (from, span) in wildcard_reexports {
+            if let Some(target_path) = self.resolve_path(current_path, &from) {
+                // Load the target module (circular deps handled by load_module)
+                if let Ok(target_module) = self.load_module(&target_path, span) {
+                    // Merge all exports from target module
+                    for (name, symbol) in target_module.exports.clone() {
+                        exports.entry(name).or_insert(symbol);
+                    }
+                }
+            }
+        }
+
+        // Third pass: resolve named re-exports with correct types
+        for (items, from, span) in named_reexports {
+            if let Some(target_path) = self.resolve_path(current_path, &from) {
+                if let Ok(target_module) = self.load_module(&target_path, span) {
+                    for item in items {
+                        let export_name = item.alias.as_ref().unwrap_or(&item.name);
+                        // Try to get the correct type from target module
+                        if let Some(target_symbol) = target_module.exports.get(&item.name) {
                             exports.insert(
                                 export_name.clone(),
                                 ExportedSymbol {
                                     name: item.name.clone(),
-                                    kind: ExportKind::Variable, // Type determined later
-                                    span: stmt.span,
+                                    kind: target_symbol.kind.clone(),
+                                    span,
+                                },
+                            );
+                        } else {
+                            // Symbol not found in target, use Variable as fallback
+                            exports.insert(
+                                export_name.clone(),
+                                ExportedSymbol {
+                                    name: item.name.clone(),
+                                    kind: ExportKind::Variable,
+                                    span,
                                 },
                             );
                         }

--- a/src/semantic/modules.rs
+++ b/src/semantic/modules.rs
@@ -307,14 +307,19 @@ impl ModuleLoader {
                     }
                     ExportItems::Named(items) => {
                         // Handle صدّر { name1، name2 }
-                        // These are re-exports of previously defined/imported symbols
+                        // Store for later pass to resolve after direct exports are collected
                         for item in items {
                             let export_name = item.alias.as_ref().unwrap_or(&item.name);
+                            // Look up the symbol in already collected exports (from Declaration exports)
+                            let kind = exports
+                                .get(&item.name)
+                                .map(|s| s.kind.clone())
+                                .unwrap_or(ExportKind::Variable);
                             exports.insert(
                                 export_name.clone(),
                                 ExportedSymbol {
                                     name: item.name.clone(),
-                                    kind: ExportKind::Variable, // Type determined later
+                                    kind,
                                     span: stmt.span,
                                 },
                             );


### PR DESCRIPTION
Add parser support for three new export patterns:
- Named exports: صدّر { name1، name2 }
- Wildcard re-exports: صدّر * من "module"
- Named re-exports: صدّر { name1، name2 } من "module"

This fixes the misleading "expected الحمد_لله at end of file" error that occurred when parsing stdlib modules using grouped exports.

Changes:
- Add ExportItems enum and ExportItem struct to AST
- Update parse_export_statement() to handle all export patterns
- Update semantic analyzer, IR builder, formatter, and doc extractor
- Update collect_exports() in modules.rs for new export types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Export statements now distinguish declaration exports, named exports, wildcard re-exports, and named re-exports with a richer internal representation.
* **Bug Fixes / Behavior**
  * Formatter and analyzer consistently handle the various export forms, improving formatted output (including alias presentation) and semantic validation.
* **Feature**
  * Multi-pass export resolution enables correct merging and resolution of re-exports across modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->